### PR TITLE
update superagent dependency to latest version 3.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/ordercloud-api/OrderCloud-JavaScript-SDK"
   },
   "dependencies": {
-    "superagent": "1.7.1"
+    "superagent": "3.8.2"
   },
   "devDependencies": {
     "bowserify": "^10.2.1",


### PR DESCRIPTION
Ran into issues using this package with the most current Node version due to the downstream dependency on formidable@1.0.17