### PR TITLE
Add support for browser usage in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Four51 Inc. <ordercloud@four51.com>",
   "license": "MIT",
   "main": "src/index.js",
+  "browser": "dist/ordercloud-javascript-sdk.min.js",
   "scripts": {
     "build": "npm run concat && npm run minify",
     "concat": "browserify ./src/index.js --outfile ./dist/ordercloud-javascript-sdk.js --standalone OrderCloudSDK",


### PR DESCRIPTION
- See https://docs.npmjs.com/files/package.json#browser

In order to use this library in both a node environment and the browser, we should add a `browser` entry into package.json.  Webpack and other build systems can read the entry and choose the correct file based on the target.