### PR TITLE
Add optional customRoles array to auth methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the ordercloud-javascript-sdk will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.7.8] - 2022-05-04
+### Added
+- Added an optional `customRoles` array to the authentication methods to support authenticating with custom roles, in addition to standard ApiRoles.
 ## [4.6.8] - 2022-05-02
 ### Fixed
 - Docs now up to date with API v1.0.235 and previous changes to DecodedToken.role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.6.8] - 2022-05-02
 ### Fixed
 - Docs now up to date with API v1.0.235 and previous changes to DecodedToken.role
+### Removed
+- The ApiRole `InventoryAdmin` was removed from the OrderCloud API and is now considered a custom role.  This role was removed from the `ApiRole` type definition.  This could be a breaking change if your application uses the role `InventoryAdmin`.  In this case, we recommend making this role a custom role.
 ## [4.6.7] - 2022-04-27
 ### Fixed
 - DecodedToken.role was not properly typed. It is now (ApiRole[] | ApiRole | undefined)

--- a/codegen/templates/api/Auth.ts
+++ b/codegen/templates/api/Auth.ts
@@ -32,6 +32,7 @@ class Auth {
    * @param password of the user logging in
    * @param client_id of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
    * @param requestOptions.requestType Provide a value that can be used to identify the type of request. Useful for error logs.
    */
@@ -40,6 +41,7 @@ class Auth {
     password: string,
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -48,12 +50,18 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'password',
       username,
       password,
       client_id: clientID,
-      scope: scope.join(' '),
+      scope: _scope,
     }
     const configuration = Configuration.Get()
     const response = await axios
@@ -81,6 +89,7 @@ class Auth {
    * @param password of the user logging in
    * @param clientID of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
@@ -92,6 +101,7 @@ class Auth {
     password: string,
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -100,9 +110,15 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'password',
-      scope: scope.join(' '),
+      scope: _scope,
       client_id: clientID,
       username,
       password,
@@ -132,6 +148,7 @@ class Auth {
    * @param clientSecret of the application
    * @param clientID of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
@@ -141,6 +158,7 @@ class Auth {
     clientSecret: string,
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -149,9 +167,15 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'client_credentials',
-      scope: scope.join(' '),
+      scope: _scope,
       client_id: clientID,
       client_secret: clientSecret,
     }
@@ -217,12 +241,14 @@ class Auth {
    *
    * @param clientID of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
    * @param requestOptions.requestType Provide a value that can be used to identify the type of request. Useful for error logs.
    */
   public async Anonymous(
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -231,10 +257,16 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'client_credentials',
       client_id: clientID,
-      scope: scope.join(' '),
+      scope: _scope,
     }
     const configuration = Configuration.Get()
     const response = await axios

--- a/docs/classes/auth.html
+++ b/docs/classes/auth.html
@@ -89,7 +89,7 @@
 					<a name="anonymous" class="tsd-anchor"></a>
 					<h3>Anonymous</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">Anonymous<span class="tsd-signature-symbol">(</span>clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">Anonymous<span class="tsd-signature-symbol">(</span>clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, customRoles<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -114,6 +114,12 @@
 									<h5>scope: <a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>roles being requested - space delimited string or array</p>
+									</div>
+								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> customRoles: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>optional custom roles being requested - string array</p>
 									</div>
 								</li>
 								<li>
@@ -142,7 +148,7 @@
 					<a name="clientcredentials" class="tsd-anchor"></a>
 					<h3>Client<wbr>Credentials</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">Client<wbr>Credentials<span class="tsd-signature-symbol">(</span>clientSecret<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">Client<wbr>Credentials<span class="tsd-signature-symbol">(</span>clientSecret<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, customRoles<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -176,6 +182,12 @@
 									</div>
 								</li>
 								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> customRoles: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>optional custom roles being requested - string array</p>
+									</div>
+								</li>
+								<li>
 									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> requestOptions: <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter">
@@ -201,7 +213,7 @@
 					<a name="elevatedlogin" class="tsd-anchor"></a>
 					<h3>Elevated<wbr>Login</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">Elevated<wbr>Login<span class="tsd-signature-symbol">(</span>clientSecret<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, username<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, password<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">Elevated<wbr>Login<span class="tsd-signature-symbol">(</span>clientSecret<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, username<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, password<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, customRoles<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -247,6 +259,12 @@
 									</div>
 								</li>
 								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> customRoles: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>optional custom roles being requested - string array</p>
+									</div>
+								</li>
+								<li>
 									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> requestOptions: <span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter">
@@ -272,7 +290,7 @@
 					<a name="login" class="tsd-anchor"></a>
 					<h3>Login</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">Login<span class="tsd-signature-symbol">(</span>username<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, password<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">Login<span class="tsd-signature-symbol">(</span>username<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, password<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, clientID<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, scope<span class="tsd-signature-symbol">: </span><a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span>, customRoles<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span>, requestOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../index.html#requireddeep" class="tsd-signature-type">RequiredDeep</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/accesstoken.html" class="tsd-signature-type">AccessToken</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -306,6 +324,12 @@
 									<h5>scope: <a href="../index.html#apirole" class="tsd-signature-type">ApiRole</a><span class="tsd-signature-symbol">[]</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>roles being requested - space delimited string or array</p>
+									</div>
+								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> customRoles: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>optional custom roles being requested - string array</p>
 									</div>
 								</li>
 								<li>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ordercloud-javascript-sdk",
   "description": "The offical Javascript SDK for the Ordercloud ecommerce API",
   "author": "Four51 OrderCloud",
-  "version": "4.6.8",
+  "version": "4.7.8",
   "main": "dist/index.js",
   "umd:main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/src/api/Auth.ts
+++ b/src/api/Auth.ts
@@ -32,6 +32,7 @@ class Auth {
    * @param password of the user logging in
    * @param client_id of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
    * @param requestOptions.requestType Provide a value that can be used to identify the type of request. Useful for error logs.
    */
@@ -40,6 +41,7 @@ class Auth {
     password: string,
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -48,12 +50,18 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'password',
       username,
       password,
       client_id: clientID,
-      scope: scope.join(' '),
+      scope: _scope,
     }
     const configuration = Configuration.Get()
     const response = await axios
@@ -81,6 +89,7 @@ class Auth {
    * @param password of the user logging in
    * @param clientID of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
@@ -92,6 +101,7 @@ class Auth {
     password: string,
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -100,9 +110,15 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'password',
-      scope: scope.join(' '),
+      scope: _scope,
       client_id: clientID,
       username,
       password,
@@ -132,6 +148,7 @@ class Auth {
    * @param clientSecret of the application
    * @param clientID of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
    * @param reportProgress flag to report request and response progress.
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
@@ -141,6 +158,7 @@ class Auth {
     clientSecret: string,
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -149,9 +167,15 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'client_credentials',
-      scope: scope.join(' '),
+      scope: _scope,
       client_id: clientID,
       client_secret: clientSecret,
     }
@@ -217,12 +241,14 @@ class Auth {
    *
    * @param clientID of the application the user is logging into
    * @param scope roles being requested - space delimited string or array
+   * @param customRoles optional custom roles being requested - string array
    * @param requestOptions.cancelToken Provide an [axios cancelToken](https://github.com/axios/axios#cancellation) that can be used to cancel the request.
    * @param requestOptions.requestType Provide a value that can be used to identify the type of request. Useful for error logs.
    */
   public async Anonymous(
     clientID: string,
     scope: ApiRole[],
+    customRoles?: string[],
     requestOptions: {
       cancelToken?: CancelToken
       requestType?: string
@@ -231,10 +257,16 @@ class Auth {
     if (!Array.isArray(scope)) {
       throw new Error('scope must be a string array')
     }
+    if (customRoles != null && !Array.isArray(customRoles)) {
+      throw new Error('custom roles must be defined as a string array')
+    }
+    var _scope = customRoles?.length
+      ? `${scope.join(' ')} ${customRoles.join(' ')}`
+      : scope.join(' ')
     const body = {
       grant_type: 'client_credentials',
       client_id: clientID,
-      scope: scope.join(' '),
+      scope: _scope,
     }
     const configuration = Configuration.Get()
     const response = await axios


### PR DESCRIPTION
Add optional customRoles string array to authentication methods to support authentication with custom roles in addition to the standard ApiRoles.  

This helps ease the transition of the role "InventoryAdmin" being removed from the API and now considered a custom role.