### PR TITLE
🔧 bug fix for tag and publish workflow

### DIFF
--- a/.github/workflows/tag-and-publish.yml
+++ b/.github/workflows/tag-and-publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest # ubuntu throws error on build
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
After adding the build step back in, we need to update runs-on to `windows-latest` to allow the workflow to run successfully